### PR TITLE
Add ability to take input from file

### DIFF
--- a/.github/testing/students.csv
+++ b/.github/testing/students.csv
@@ -1,0 +1,5 @@
+First Name,Last Name,Age,Course
+Alex,Abrams,21,Physics
+Bailey,Brown,22,Literature
+Charlie,Clark,20,History
+Dylan,Dobbs,53,Computer Science

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,3 +128,27 @@ jobs:
         env:
           HAVE: ${{ steps.grawk.outputs.result }}
           WANT: "b"
+
+  input-from-file:
+    name: Process Input From Given Filename
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - id: grawk
+        name: Run Grawk
+        uses: ./
+        with:
+          input-file: .github/testing/students.csv
+          separator: ','
+          program: |
+            $1 == Alex {
+              print $2, $1: $3 year old $4 student
+            }
+
+      - name: Assert Output Is Correct
+        run: test "${HAVE}" = "${WANT}"
+        env:
+          HAVE: ${{ steps.grawk.outputs.result }}
+          WANT: "Abrams, Alex: 21 year old Physics student"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,8 +143,8 @@ jobs:
           input-file: .github/testing/students.csv
           separator: ','
           program: |
-            $1 == Alex {
-              print $2, $1: $3 year old $4 student
+            $1 == "Alex" {
+              print $2 ", " $1 ": " $3 " year old " $4 " student"
             }
 
       - name: Assert Output Is Correct

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
 
         if [ ! -z "${DATA_TEXT}" ]
         then
-          echo "${DATA_TEXT}" >> "$DATA_FULL}"
+          echo "${DATA_TEXT}" >> "${DATA_FULL}"
         fi
 
         echo "" >> "${DATA_FULL}"

--- a/action.yml
+++ b/action.yml
@@ -46,47 +46,50 @@ runs:
     - name: "Get Config"
       id: config
       shell: bash
-      env:
-        DATA_TEXT: ${{ inputs.input        }}
-        DATA_FILE: ${{ inputs.input-file   }}
-        DATA_FULL: ${{ runner.temp         }}/std.in
-        SEPARATOR: ${{ inputs.separator    }}
-        PROG_TEXT: ${{ inputs.program      }}
-        PROG_FILE: ${{ inputs.program-file }}
-        PROG_FULL: ${{ runner.temp         }}/gr.awk
       run: |
-        if [ -f "${DATA_FILE}" ]
-        then
-          cat "${DATA_FILE}" >> "${DATA_FULL}"
-        fi
+        echo "data-file=${{ runner.temp }}/std.in" >> "${GITHUB_OUTPUT}"
+        echo "prog-file=${{ runner.temp }}/gr.awk" >> "${GITHUB_OUTPUT}"
 
-        if [ ! -z "${DATA_TEXT}" ]
-        then
-          echo "${DATA_TEXT}" >> "${DATA_FULL}"
-        fi
+    - name: "Create Standard Input"
+      shell: bash
+      run: touch "${{ steps.config.outputs.data-file }}"
 
-        echo "" >> "${DATA_FULL}"
+    - name: "Add Input File to Standard Input"
+      if: inputs.input-file != ''
+      shell: bash
+      run: cat "${DATA_FILE}" >> "${{ steps.config.outputs.data-file }}"
+      env:
+        DATA_FILE: ${{ inputs.input-file }}
 
-        echo "data-file=${DATA_FULL}" >> "${GITHUB_OUTPUT}"
-
-        if [ -f "${PROG_FILE}" ]
-        then
-          cat "${PROG_FILE}" >> "${PROG_FULL}"
-        fi
-
-        if [ ! -z "${PROG_TEXT}" ]
-        then
-          echo "${PROG_TEXT}" >> "${PROG_FULL}"
-        fi
-
-        echo "" >> "${PROG_FULL}"
-
-        echo "prog-file=${PROG_FULL}" >> "${GITHUB_OUTPUT}"
+    - name: "Add Raw Input to Standard Input"
+      if: inputs.input != ''
+      shell: bash
+      run: echo "${DATA_TEXT}" >> "${{ steps.config.outputs.data-file }}"
+      env:
+        DATA_TEXT: ${{ inputs.input }}
 
     - name: "Debug Grawk Input"
       if: runner.debug == 1
       shell: bash
       run: cat "${{ steps.config.outputs.data-file }}"
+
+    - name: "Create Program"
+      shell: bash
+      run: touch "${{ steps.config.outputs.prog-file }}"
+
+    - name: "Add Program File to Program"
+      if: inputs.program-file != ''
+      shell: bash
+      run: cat "${DATA_FILE}" >> "${{ steps.config.outputs.prog-file }}"
+      env:
+        PROG_FILE: ${{ inputs.program-file }}
+
+    - name: "Add Raw Program to Program"
+      if: inputs.program != ''
+      shell: bash
+      run: echo "${DATA_TEXT}" >> "${{ steps.config.outputs.prog-file }}"
+      env:
+        PROG_TEXT: ${{ inputs.program }}
 
     - name: "Debug Grawk Program"
       if: runner.debug == 1
@@ -100,7 +103,6 @@ runs:
         SEPARATOR: ${{ inputs.separator }}
       run: |
         delimiter="$(openssl rand -hex 8)"
-
         echo "result<<${delimiter}" >> "${GITHUB_OUTPUT}"
         cat "${{ steps.config.outputs.data-file }}" | awk ${{ inputs.separator && '-F "${SEPARATOR}"' || '' }} -f "${{ steps.config.outputs.prog-file }}" | tee -a "${GITHUB_OUTPUT}"
         echo "${delimiter}" >> "${GITHUB_OUTPUT}"

--- a/action.yml
+++ b/action.yml
@@ -80,14 +80,14 @@ runs:
     - name: "Add Program File to Program"
       if: inputs.program-file != ''
       shell: bash
-      run: cat "${DATA_FILE}" | tee -a "${{ steps.config.outputs.prog-file }}"
+      run: cat "${PROG_FILE}" | tee -a "${{ steps.config.outputs.prog-file }}"
       env:
         PROG_FILE: ${{ inputs.program-file }}
 
     - name: "Add Raw Program to Program"
       if: inputs.program != ''
       shell: bash
-      run: echo "${DATA_TEXT}" | tee -a "${{ steps.config.outputs.prog-file }}"
+      run: echo "${PROG_TEXT}" | tee -a "${{ steps.config.outputs.prog-file }}"
       env:
         PROG_TEXT: ${{ inputs.program }}
 

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,14 @@ branding:
 
 inputs:
   input:
-    required: true
+    required: false
     description: |
       The input to the awk program.
+
+  input-file:
+    required: false
+    description: |
+      The pathname of the file containing the input to the awk program.
 
   separator:
     required: false
@@ -42,12 +47,28 @@ runs:
       id: config
       shell: bash
       env:
-        STD_INPUT: ${{ inputs.input        }}
+        DATA_TEXT: ${{ inputs.input        }}
+        DATA_FILE: ${{ inputs.input-file   }}
+        DATA_FULL: ${{ runner.temp         }}/std.in
         SEPARATOR: ${{ inputs.separator    }}
         PROG_TEXT: ${{ inputs.program      }}
         PROG_FILE: ${{ inputs.program-file }}
         PROG_FULL: ${{ runner.temp         }}/gr.awk
       run: |
+        if [ -f "${DATA_FILE}" ]
+        then
+          cat "${DATA_FILE}" >> "${DATA_FULL}"
+        fi
+
+        if [ ! -z "${DATA_TEXT}" ]
+        then
+          echo "${DATA_TEXT}" >> "$DATA_FULL}"
+        fi
+
+        echo "" >> "${DATA_FULL}"
+
+        echo "data-file=${DATA_FULL}" >> "${GITHUB_OUTPUT}"
+
         if [ -f "${PROG_FILE}" ]
         then
           cat "${PROG_FILE}" >> "${PROG_FULL}"
@@ -62,7 +83,12 @@ runs:
 
         echo "prog-file=${PROG_FULL}" >> "${GITHUB_OUTPUT}"
 
-    - name: "Debug Grawk"
+    - name: "Debug Grawk Input"
+      if: runner.debug == 1
+      shell: bash
+      run: cat "${{ steps.config.outputs.data-file }}"
+
+    - name: "Debug Grawk Program"
       if: runner.debug == 1
       shell: bash
       run: cat "${{ steps.config.outputs.prog-file }}"
@@ -72,10 +98,9 @@ runs:
       shell: bash
       env:
         SEPARATOR: ${{ inputs.separator }}
-        STD_INPUT: ${{ inputs.input     }}
       run: |
         delimiter="$(openssl rand -hex 8)"
 
         echo "result<<${delimiter}" >> "${GITHUB_OUTPUT}"
-        echo "${STD_INPUT}" | awk ${{ inputs.separator && '-F "${SEPARATOR}"' || '' }} -f "${{ steps.config.outputs.prog-file }}" | tee -a "${GITHUB_OUTPUT}"
+        cat "${{ steps.config.outputs.data-file }}" | awk ${{ inputs.separator && '-F "${SEPARATOR}"' || '' }} -f "${{ steps.config.outputs.prog-file }}" | tee -a "${GITHUB_OUTPUT}"
         echo "${delimiter}" >> "${GITHUB_OUTPUT}"

--- a/action.yml
+++ b/action.yml
@@ -57,14 +57,14 @@ runs:
     - name: "Add Input File to Standard Input"
       if: inputs.input-file != ''
       shell: bash
-      run: cat "${DATA_FILE}" >> "${{ steps.config.outputs.data-file }}"
+      run: cat "${DATA_FILE}" | tee -a "${{ steps.config.outputs.data-file }}"
       env:
         DATA_FILE: ${{ inputs.input-file }}
 
     - name: "Add Raw Input to Standard Input"
       if: inputs.input != ''
       shell: bash
-      run: echo "${DATA_TEXT}" >> "${{ steps.config.outputs.data-file }}"
+      run: echo "${DATA_TEXT}" | tee -a "${{ steps.config.outputs.data-file }}"
       env:
         DATA_TEXT: ${{ inputs.input }}
 
@@ -80,14 +80,14 @@ runs:
     - name: "Add Program File to Program"
       if: inputs.program-file != ''
       shell: bash
-      run: cat "${DATA_FILE}" >> "${{ steps.config.outputs.prog-file }}"
+      run: cat "${DATA_FILE}" | tee -a "${{ steps.config.outputs.prog-file }}"
       env:
         PROG_FILE: ${{ inputs.program-file }}
 
     - name: "Add Raw Program to Program"
       if: inputs.program != ''
       shell: bash
-      run: echo "${DATA_TEXT}" >> "${{ steps.config.outputs.prog-file }}"
+      run: echo "${DATA_TEXT}" | tee -a "${{ steps.config.outputs.prog-file }}"
       env:
         PROG_TEXT: ${{ inputs.program }}
 


### PR DESCRIPTION
This adds a new unit test to run grawk on a local file, in this case one that is checked out locally. Adding the necessary functionality lead to major refactor of the action, in particular to the way that internal files are handled. All changes are backwards compatible, note however that the input can now come from either a file or previous step output, this is handled the same way as the program source, meaning that either or both or neither may be specified.